### PR TITLE
Translations

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -3,7 +3,7 @@
 
 # The language to be used in messages in this plugin.
 # Available options:
-#  en
+# - en
 Language: en
 
 # Whether to make pets invulnerable to any damage, or allow damaging them.
@@ -53,8 +53,8 @@ Give-Experience-For-Feeding: true
 
 # The database used to store data of pets in. This is only relevant if storage to database is turned to true.
 # Options:
-#  MySQL
-#  SQLite
+# - MySQL
+# - SQLite
 Database: SQLite
 
 # MySQL information. This is only relevant if database above is set to MySQL.

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,6 +1,11 @@
 ---
 # Configuration file for BlockPets, a pets plugin by BlockHorizons.
 
+# The language to be used in messages in this plugin.
+# Available options:
+#  en
+Language: en
+
 # Whether to make pets invulnerable to any damage, or allow damaging them.
 Invulnerable-Pets: false
 
@@ -48,8 +53,8 @@ Give-Experience-For-Feeding: true
 
 # The database used to store data of pets in. This is only relevant if storage to database is turned to true.
 # Options:
-# MySQL
-# SQLite
+#  MySQL
+#  SQLite
 Database: SQLite
 
 # MySQL information. This is only relevant if database above is set to MySQL.

--- a/resources/languages/en.yml
+++ b/resources/languages/en.yml
@@ -1,0 +1,20 @@
+---
+# English messages file for BlockPets, a pets plugin by BlockHorizons.
+# TODO: replace § with &
+
+prefix:
+  warning: "[Warning]"
+
+commands:
+  errors:
+    console-use: "That command can only be used by players."
+    no-permission: "You don't have permission to use that command."
+    player:
+      not-found: "The given player cannot be found."
+      no-pet: "You do not own a pet with the given name."
+      no-pet-other: "The given player does not own a pet with that name."
+         
+  changepetname:
+    no-permission: "You don't have permission to change the name of pets from other players."
+    success: "Successfully changed the name of %s §r§ato %s."
+...

--- a/resources/languages/en.yml
+++ b/resources/languages/en.yml
@@ -1,20 +1,48 @@
 ---
 # English messages file for BlockPets, a pets plugin by BlockHorizons.
-# TODO: replace § with &
+# TODO: replace § with &, add all language strings
 
 prefix:
-  warning: "[Warning]"
+  warning: "§c[§6Warning§c]"
 
 commands:
   errors:
     console-use: "That command can only be used by players."
     no-permission: "You don't have permission to use that command."
+    
+    pet:
+      doesnt-exist: "A pet with the given name doesn't exist."
+      numeric: "The pet scale should be numeric."
+      
     player:
       not-found: "The given player cannot be found."
       no-pet: "You do not own a pet with the given name."
       no-pet-other: "The given player does not own a pet with that name."
+      already-own-pet: "You already own a pet with that name."
          
   changepetname:
     no-permission: "You don't have permission to change the name of pets from other players."
     success: "Successfully changed the name of %s §r§ato %s."
+    
+  clearpet:
+    success: "Successfully cleared the pet §b%s§a."
+    
+  healpet:
+    success: "The pet %s §r§a has been healed successfully!"
+    
+  spawnpet:
+    no-permission: "You don't have permission to spawn that pet."
+    no-permission-others: "You don't have permission to spawn pets to others."
+    success: "Successfully spawned a pet with the name §b%s§a."
+    success-other: "You have received a pet with the name §b%s§a."
+    name: "Please type a name for your pet in chat"
+    selecting-name: "%s is now selecting a name for their pet."
+    exceeded-limit: "%s exceeded the pet limit."
+    
+  removepet:
+    success: "Succesfully removed the pet §b%s§a."
+    
+  togglepet:
+    success: "Successfully toggled your pets %s."
+    success-others: "Successfully toggle the pet §b%s §r§a %s."
 ...

--- a/src/BlockHorizons/BlockPets/Loader.php
+++ b/src/BlockHorizons/BlockPets/Loader.php
@@ -14,6 +14,7 @@ use BlockHorizons\BlockPets\commands\SpawnPetCommand;
 use BlockHorizons\BlockPets\commands\TogglePetCommand;
 use BlockHorizons\BlockPets\configurable\BlockPetsConfig;
 use BlockHorizons\BlockPets\configurable\PetProperties;
+use BlockHorizons\BlockPets\configurable\LanguageConfig;
 use BlockHorizons\BlockPets\events\PetRemoveEvent;
 use BlockHorizons\BlockPets\events\PetSpawnEvent;
 use BlockHorizons\BlockPets\listeners\EventListener;
@@ -190,12 +191,17 @@ class Loader extends PluginBase {
 		GuardianPet::class,
 		ArrowPet::class
 	];
+	
+	public $availableLanguages = [
+	    "en"
+	];
 
 	/** @var array */
 	public $selectingName = [];
 
 	private $bpConfig;
 	private $pProperties;
+	private $language;
 
 	private $database;
 	private $toggledOff = [];
@@ -211,6 +217,7 @@ class Loader extends PluginBase {
 
 		$this->bpConfig = new BlockPetsConfig($this);
 		$this->pProperties = new PetProperties($this);
+		$this->language = new LanguageConfig($this);
 		$this->selectDatabase();
 	}
 
@@ -263,6 +270,19 @@ class Loader extends PluginBase {
 	 */
 	public function getBlockPetsConfig(): BlockPetsConfig {
 		return $this->bpConfig;
+	}
+	
+	/**
+	 * @param string $key
+	 * @param array  $params
+	 *
+	 * @return string
+	 */
+	public function translate(string $key, array $params = []) {
+	    if(!empty($params)) {
+	        return vsprintf($this->language->get($key), $params);
+	    }
+	    return $this->language->get($key);
 	}
 
 	/**

--- a/src/BlockHorizons/BlockPets/Loader.php
+++ b/src/BlockHorizons/BlockPets/Loader.php
@@ -280,9 +280,9 @@ class Loader extends PluginBase {
 	 */
 	public function translate(string $key, array $params = []) {
 	    if(!empty($params)) {
-	        return vsprintf($this->language->get($key), $params);
+	        return vsprintf($this->getLanguage()->get($key), $params);
 	    }
-	    return $this->language->get($key);
+	    return $this->getLanguage()->get($key);
 	}
 
 	/**
@@ -295,6 +295,13 @@ class Loader extends PluginBase {
 				$clearLaggPlugin->exemptEntity($event->getEntity());
 			}
 		}
+	}
+
+	/**
+	 * @return LanguageConfig
+	 */
+	public function getLanguage(): LanguageConfig {
+		return $this->language;
 	}
 
 	/**

--- a/src/BlockHorizons/BlockPets/commands/BaseCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/BaseCommand.php
@@ -22,8 +22,23 @@ abstract class BaseCommand extends Command implements PluginIdentifiableCommand 
 	/**
 	 * @param CommandSender $sender
 	 */
-	public function sendConsoleError(CommandSender $sender) {
-		$sender->sendMessage(TF::RED . "[Warning] That command can only be used by players.");
+	public function sendConsoleError(CommandSender $sender) {   
+		$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.console-use"));
+	}
+	
+	/**
+	 * @param CommandSender $sender
+	 */
+	public function sendPermissionMessage(CommandSender $sender) {
+	    $this->sendWarning($sender, $this->getLoader()->translate("commands." . $this->getName() . ".no-permission") ?? $this->getLoader()->translate("commands.no-permission"));
+	}
+	
+	/**
+	 * @param CommandSender $sender
+	 * @param string        $text
+	 */
+	public function sendWarning(CommandSender $sender, string $text) {
+	    $sender->sendMessage(TF::RED . $this->getLoader()->translate("prefix.warning") . " " . $text);
 	}
 
 	/**
@@ -38,13 +53,6 @@ abstract class BaseCommand extends Command implements PluginIdentifiableCommand 
 	 */
 	public function getLoader(): Loader {
 		return $this->loader;
-	}
-
-	/**
-	 * @param CommandSender $sender
-	 */
-	public function sendNoPermission(CommandSender $sender) {
-		$sender->sendMessage(TF::RED . "[Warning] You don't have permission to use that command.");
 	}
 
 	public function generateCustomCommandData(Player $player): array {

--- a/src/BlockHorizons/BlockPets/commands/ChangePetNameCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/ChangePetNameCommand.php
@@ -28,31 +28,37 @@ class ChangePetNameCommand extends BaseCommand {
 
 		if(isset($args[2])) {
 			if($sender->hasPermission("blockpets.command.changepetname.others")) {
-				$sender->sendMessage(TF::RED . "[Warning] You don't have permission to change the name of pets from other players.");
+				$this->sendPermissionMessage($sender);
 				return true;
 			}
 			if(($player = $this->getLoader()->getServer()->getPlayer($args[2])) === null) {
-				$sender->sendMessage(TF::RED . "[Warning] The given player could not be found.");
+				$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.player.not-found"));
 				return true;
 			}
 			if(($pet = $this->getLoader()->getPetByName($args[0], $player)) === null) {
-				$sender->sendMessage(TF::RED . "[Warning] The given player does not own a pet with that name.");
+				$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.player.no-pet-other"));
 				return true;
 			}
 			$oldName = $pet->getPetName();
 			$pet->changeName($newName);
-			$sender->sendMessage(TF::GREEN . "Successfully changed the name of " . $oldName . TF::RESET . TF::GREEN . "  to " . $newName);
+			$sender->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.changepetname.success", [
+			    $oldName,
+			    $newName
+			]));
 			return true;
 		} else {
 			if(($pet = $this->getLoader()->getPetByName($args[0], $sender)) === null) {
-				$sender->sendMessage(TF::RED . "[Warning] You don't own a pet with the given name");
+				$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.player.no-pet"));
 				return true;
 			}
 		}
 
 		$oldName = $pet->getPetName();
 		$pet->changeName($newName);
-		$sender->sendMessage(TF::GREEN . "Successfully changed the name of " . $oldName . TF::RESET . TF::GREEN . "  to " . $newName);
+		$sender->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.changepetname.success", [
+                $oldName,
+                $newName
+        ]));
 		return true;
 	}
 }

--- a/src/BlockHorizons/BlockPets/commands/ClearPetCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/ClearPetCommand.php
@@ -26,15 +26,15 @@ class ClearPetCommand extends BaseCommand {
 		}
 
 		if(($pet = $this->getLoader()->getPetByName($args[0], $sender)) === null) {
-			$sender->sendMessage(TF::RED . "[Warning] A pet with that name doesn't exist.");
+		    $this->sendWarning($sender, $this->getLoader()->translate("commands.errors.pet.doesnt-exist"));
 			return true;
 		}
 
 		if($this->getLoader()->removePet($pet->getPetName(), $sender) === false) {
-			$sender->sendMessage(TF::RED . "[Warning] A plugin has cancelled the removal of this pet.");
+			$this->sendWarning($sender, "A plugin has cancelled the removal of this pet.");
 			return true;
 		}
-		$sender->sendMessage(TF::GREEN . "Successfully cleared the pet: " . TF::AQUA . $pet->getPetName());
+		$sender->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.clearpet.success", [$pet->getPetName()]));
 		return true;
 	}
 }

--- a/src/BlockHorizons/BlockPets/commands/ClearPetCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/ClearPetCommand.php
@@ -16,7 +16,7 @@ class ClearPetCommand extends BaseCommand {
 
 	public function execute(CommandSender $sender, $commandLabel, array $args): bool {
 		if(!$this->testPermission($sender)) {
-			$this->sendNoPermission($sender);
+			$this->sendPermissionMessage($sender);
 			return true;
 		}
 

--- a/src/BlockHorizons/BlockPets/commands/HealPetCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/HealPetCommand.php
@@ -16,18 +16,18 @@ class HealPetCommand extends BaseCommand {
 
 	public function execute(CommandSender $sender, $commandLabel, array $args): bool {
 		if(!$this->testPermission($sender)) {
-			$this->sendNoPermission($sender);
+			$this->sendPermissionMessage($sender);
 			return true;
 		}
 
 		if(($pet = $this->getLoader()->getPetByName($args[0])) === null) {
-			$sender->sendMessage(TF::RED . "[Warning] A pet with that name doesn't exist.");
+			$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.pet.doesnt-exist"));
 			return true;
 		}
 
 		if(isset($args[1])) {
 			if(($player = $this->getLoader()->getServer()->getPlayer($args[1])) === null) {
-				$sender->sendMessage(TF::RED . "[Warning] The given player could not be found.");
+				$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.player.not-found"));
 				return true;
 			}
 			if(($pet = $this->getLoader()->getPetByName($args[0], $player)) === null) {

--- a/src/BlockHorizons/BlockPets/commands/HealPetCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/HealPetCommand.php
@@ -31,18 +31,18 @@ class HealPetCommand extends BaseCommand {
 				return true;
 			}
 			if(($pet = $this->getLoader()->getPetByName($args[0], $player)) === null) {
-				$sender->sendMessage(TF::RED . "[Warning] The given player does not own a pet with that name.");
+				$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.player.no-pet-other"));
 				return true;
 			}
 			$pet->fullHeal();
 			$pet->getLevel()->addParticle(new HeartParticle($pet->add(0, 2), 4));
-			$sender->sendMessage(TF::GREEN . "The pet " . $pet->getPetName() . TF::RESET . TF::GREEN . " has been healed successfully!");
+			$sender->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.healpet.success", [$pet->getPetName()]));
 			return true;
 		}
 
 		$pet->fullHeal();
 		$pet->getLevel()->addParticle(new HeartParticle($pet->add(0, 2), 4));
-		$sender->sendMessage(TF::GREEN . "The pet " . $pet->getPetName() . TF::RESET . TF::GREEN . " has been healed successfully!");
+		$sender->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.healpet.success", [$pet->getPetName()]));
 		return true;
 	}
 }

--- a/src/BlockHorizons/BlockPets/commands/LevelUpPetCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/LevelUpPetCommand.php
@@ -16,7 +16,7 @@ class LevelUpPetCommand extends BaseCommand {
 
 	public function execute(CommandSender $sender, $commandLabel, array $args): bool {
 		if(!$this->testPermission($sender)) {
-			$this->sendNoPermission($sender);
+			$this->sendPermissionMessage($sender);
 			return true;
 		}
 
@@ -26,7 +26,7 @@ class LevelUpPetCommand extends BaseCommand {
 		}
 
 		if(($pet = $this->getLoader()->getPetByName($args[0])) === null) {
-			$sender->sendMessage(TF::RED . "[Warning] A pet with that name doesn't exist.");
+			$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.pet.doesnt-exist"));
 			return true;
 		}
 
@@ -39,7 +39,7 @@ class LevelUpPetCommand extends BaseCommand {
 
 		if(isset($args[2])) {
 			if(($player = $this->getLoader()->getServer()->getPlayer($args[2])) === null) {
-				$sender->sendMessage(TF::RED . "[Warning] The given player could not be found.");
+				$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.player.not-found"));
 				return true;
 			}
 			if(($pet = $this->getLoader()->getPetByName($args[0], $player)) === null) {

--- a/src/BlockHorizons/BlockPets/commands/LevelUpPetCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/LevelUpPetCommand.php
@@ -43,7 +43,7 @@ class LevelUpPetCommand extends BaseCommand {
 				return true;
 			}
 			if(($pet = $this->getLoader()->getPetByName($args[0], $player)) === null) {
-				$sender->sendMessage(TF::RED . "[Warning] The given player does not own a pet with that name.");
+				$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.player.no-pet-other"));
 				return true;
 			}
 			$pet->levelUp($amount);

--- a/src/BlockHorizons/BlockPets/commands/PetCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/PetCommand.php
@@ -16,7 +16,7 @@ class PetCommand extends BaseCommand {
 
 	public function execute(CommandSender $sender, $commandLabel, array $args): bool {
 		if(!$this->testPermission($sender)) {
-			$this->sendNoPermission($sender);
+			$this->sendPermissionMessage($sender);
 			return true;
 		}
 

--- a/src/BlockHorizons/BlockPets/commands/RemovePetCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/RemovePetCommand.php
@@ -20,30 +20,30 @@ class RemovePetCommand extends BaseCommand {
 		}
 
 		if(($pet = $this->getLoader()->getPetByName($args[0])) === null) {
-			$sender->sendMessage(TF::RED . "[Warning] A pet with that name doesn't exist.");
+			$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.pet.doesnt-exist"));
 			return true;
 		}
 		if(isset($args[1])) {
 			if(($player = $this->getLoader()->getServer()->getPlayer($args[1])) === null) {
-				$sender->sendMessage(TF::RED . "[Warning] The given player could not be found.");
+				$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.player.not-found"));
 				return true;
 			}
 			if(($pet = $this->getLoader()->getPetByName($args[0], $player)) === null) {
-				$sender->sendMessage(TF::RED . "[Warning] The given player does not own a pet with that name.");
+				$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.player.no-pet-other"));
 				return true;
 			}
 			if($this->getLoader()->removePet($pet->getPetName(), $player) === false) {
-				$sender->sendMessage(TF::RED . "[Warning] A plugin has cancelled the removal of this pet.");
+				$this->sendWarning($sender, "A plugin has cancelled the removal this pet.");
 				return true;
 			}
-			$sender->sendMessage(TF::GREEN . "Successfully removed the pet: " . TF::AQUA . $pet->getPetName());
+			$sender->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.removepet.success", [$pet->getPetName()]));
 			return true;
 		}
 
 		if($this->getLoader()->removePet($args[0])) {
-			$sender->sendMessage(TF::GREEN . "Successfully removed the pet: " . TF::AQUA . $pet->getPetName());
+			$sender->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.removepet.success", [$pet->getPetName()]));
 		} else {
-			$sender->sendMessage(TF::RED . "[Warning] A plugin has cancelled the removal this pet.");
+			$this->sendWarning($sender, "A plugin has cancelled the removal this pet.");
 		}
 		return true;
 	}

--- a/src/BlockHorizons/BlockPets/commands/SpawnPetCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/SpawnPetCommand.php
@@ -56,14 +56,14 @@ class SpawnPetCommand extends BaseCommand {
 				return true;
 			}
 			if(!$sender->hasPermission("blockpets.command.spawnpet.others")) {
-				$sender->sendMessage(TF::RED . "[Warning] You don't have permission to spawn pets to others.");
+				$this->sendWarning($sender, $this->getLoader()->translate("commands.spawnpet.no-permission.others"));
 				return true;
 			}
 		}
 
 		if(isset($args[2])) {
 			if(!is_numeric($args[2])) {
-				$sender->sendMessage(TF::RED . "[Warning] The pet scale should be numeric.");
+				$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.pet.numeric"));
 				return true;
 			}
 			if((float) $args[2] > $this->getLoader()->getBlockPetsConfig()->getMaxPetSize() && !($sender->hasPermission("blockpets.bypass-size-limit"))) {
@@ -82,18 +82,20 @@ class SpawnPetCommand extends BaseCommand {
 		}
 		$petName = $this->getLoader()->getPet($args[0]);
 		if($petName === null) {
-			$sender->sendMessage(TF::RED . "[Warning] Pet type " . $args[0] . " does not exist!");
+			$this->sendWarning("Pet type " . $args[0] . " does not exist!");
 			return true;
 		}
 		if(count($this->getLoader()->getPetsFrom($player)) >= $this->getLoader()->getBlockPetsConfig()->getMaxPets() && !$player->hasPermission("blockpets.bypass-limit")) {
-			$sender->sendMessage(TF::RED . "[Warning] " . $player === $sender ? "You have " : "Your target has " . " exceeded the pet limit.");
+			$this->sendMessage($sender, $this->getLoader()->translate("commands.spawnpet.exceeded-limit", [
+			    $player === $sender ? "You have " : "Your target has "
+			]));
 			return true;
 		}
 		if(!isset($args[1]) || strtolower($args[1]) === "select") {
 			if($player !== $sender) {
-				$sender->sendMessage(TF::GREEN . $player->getName() . " is now selecting a name for their pet.");
+				$sender->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.spawnpet.selecting-name", [$player->getName()]));
 			}
-			$player->sendMessage(TF::GREEN . "Please type a name for your pet in chat.");
+			$player->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.spawnpet.name"));
 			$this->getLoader()->selectingName[$player->getName()] = [
 				"petType" => $petName,
 				"scale" => isset($args[2]) ? (float) $args[2] : 1.0,
@@ -101,16 +103,16 @@ class SpawnPetCommand extends BaseCommand {
 			return true;
 		}
 		if($this->getLoader()->getPetByName($args[1], $sender) !== null) {
-			$sender->sendMessage(TF::RED . "[Warning] You already own a pet with that name.");
+			$sender->sendMessage($sender, $this->getLoader()->translate("commands.errors.player.already-own-pet"));
 			return true;
 		}
 		if($this->getLoader()->createPet((string) $petName, $player, (string) $args[1], isset($args[2]) ? (float) $args[2] : 1.0, $args[3]) === null) {
-			$sender->sendMessage(TF::RED . "[Warning] A plugin has cancelled spawning this pet.");
+			$this->sendWarning($sender, "A plugin has cancelled spawning this pet.");
 			return true;
 		}
-		$sender->sendMessage(TF::GREEN . "Successfully spawned a pet with the name: " . TF::AQUA . $args[1]);
+		$sender->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.spawnpet.success", [$args[1]]));
 		if($player->getName() !== $sender->getName()) {
-			$player->sendMessage(TF::GREEN . "You have received a pet with the name: " . TF::AQUA . $args[1]);
+			$player->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.spawnpet.success.other", [$args[1]]));
 		}
 		return true;
 	}

--- a/src/BlockHorizons/BlockPets/commands/SpawnPetCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/SpawnPetCommand.php
@@ -30,7 +30,7 @@ class SpawnPetCommand extends BaseCommand {
 		}
 		
 		if(!$this->testPermission($sender)) {
-			$this->sendNoPermission($sender);
+			$this->sendPermissionMessage($sender);
 			return true;
 		}
 
@@ -45,14 +45,14 @@ class SpawnPetCommand extends BaseCommand {
 		}
 
 		if(!$sender->hasPermission("blockpets.pet." . strtolower($args[0]))) {
-			$sender->sendMessage(TF::RED . "[Warning] You don't have permission to spawn that pet.");
+			$this->sendPermissionMessage($sender);
 			return true;
 		}
 
 		$player = $sender;
 		if(isset($args[4])) {
 			if(($player = $this->getLoader()->getServer()->getPlayer($args[4])) === null) {
-				$sender->sendMessage(TF::RED . "[Warning] That player isn't online.");
+				$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.player.not-found"));
 				return true;
 			}
 			if(!$sender->hasPermission("blockpets.command.spawnpet.others")) {

--- a/src/BlockHorizons/BlockPets/commands/TogglePetCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/TogglePetCommand.php
@@ -16,7 +16,7 @@ class TogglePetCommand extends BaseCommand {
 
 	public function execute(CommandSender $sender, $commandLabel, array $args): bool {
 		if(!$this->testPermission($sender)) {
-			$this->sendNoPermission($sender);
+			$this->sendPermissionMessage($sender);
 			return true;
 		}
 		if(!$sender instanceof Player) {
@@ -34,7 +34,7 @@ class TogglePetCommand extends BaseCommand {
 		} else {
 			$pet = $this->getLoader()->getPetByName($args[0], $sender);
 			if($pet === null) {
-				$sender->sendMessage(TF::RED . "[Warning] You do not own a pet with the given name.");
+				$this->sendWarning($sender, $this->getLoader()->translate("commands.errors.player.no-pet"));
 				return true;
 			}
 			$this->getLoader()->togglePet($pet, $sender);

--- a/src/BlockHorizons/BlockPets/commands/TogglePetCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/TogglePetCommand.php
@@ -24,13 +24,15 @@ class TogglePetCommand extends BaseCommand {
 			return true;
 		}
 		if(!isset($args[0])) {
-			$sender->sendMessage(TF::RED . "[Warning] You did not specify a pet to toggle.");
+			$this->sendWarning($sender, "You did not specify a pet to toggle.");
 			return true;
 		}
 
 		if(strtolower($args[0]) === "all") {
 			$this->getLoader()->togglePets($sender);
-			$sender->sendMessage(TF::GREEN . "Successfully toggled your pets " . ($this->getLoader()->arePetsToggledOn($sender) ? "on." : "off."));
+			$sender->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.togglepet.success", [
+			    ($this->getLoader()->arePetsToggledOn($sender) ? "on." : "off.")
+			]));
 		} else {
 			$pet = $this->getLoader()->getPetByName($args[0], $sender);
 			if($pet === null) {
@@ -38,7 +40,10 @@ class TogglePetCommand extends BaseCommand {
 				return true;
 			}
 			$this->getLoader()->togglePet($pet, $sender);
-			$sender->sendMessage(TF::GREEN . "Successfully toggled the pet " . TF::AQUA . $pet->getPetName() . TF::RESET . TF::GREEN . ($this->getLoader()->isPetToggledOn($pet, $sender) ? " off." : " on."));
+			$sender->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.togglepet.success", [
+			    $pet->getPetName(),
+			    ($this->getLoader()->isPetToggledOn($pet, $sender) ? " off." : " on.")
+			]));
 		}
 		return true;
 	}

--- a/src/BlockHorizons/BlockPets/commands/TogglePetCommand.php
+++ b/src/BlockHorizons/BlockPets/commands/TogglePetCommand.php
@@ -40,7 +40,7 @@ class TogglePetCommand extends BaseCommand {
 				return true;
 			}
 			$this->getLoader()->togglePet($pet, $sender);
-			$sender->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.togglepet.success", [
+			$sender->sendMessage(TF::GREEN . $this->getLoader()->translate("commands.togglepet.success.other", [
 			    $pet->getPetName(),
 			    ($this->getLoader()->isPetToggledOn($pet, $sender) ? " off." : " on.")
 			]));

--- a/src/BlockHorizons/BlockPets/configurable/BlockPetsConfig.php
+++ b/src/BlockHorizons/BlockPets/configurable/BlockPetsConfig.php
@@ -137,6 +137,13 @@ class BlockPetsConfig {
 	public function getDatabase(): string {
 		return (string) $this->settings["Database"] ?? "SQLite";
 	}
+	
+	/**
+	 * @return string
+	 */
+	public function getLanguage(): string {
+	    return (string) $this->settings["Language"] ?? "en";
+	}
 
 	/**
 	 * @return int

--- a/src/BlockHorizons/BlockPets/configurable/LanguageConfig.php
+++ b/src/BlockHorizons/BlockPets/configurable/LanguageConfig.php
@@ -24,7 +24,7 @@ class LanguageConfig {
             }
         }
         
-        // Don't look at this code, it harm you — or start a nuclear war. BlockHorizons and it's developers are not responsible for any physical damage as a result of staring at this code.
+        // Don't look at this code, it may harm you — or start a nuclear war. BlockHorizons and it's developers are not responsible for any physical damage received as a result of staring at this code. You have been warned.
         $this->messages = [
             "prefix.warning" => $language["prefix"]["warning"],
             

--- a/src/BlockHorizons/BlockPets/configurable/LanguageConfig.php
+++ b/src/BlockHorizons/BlockPets/configurable/LanguageConfig.php
@@ -66,7 +66,7 @@ class LanguageConfig {
     /**
      * @param string $key
      *
-     * @return mixed|null
+     * @return string|null
      */
     public function get(string $key) {
         return $this->messages[$key] ?? null;

--- a/src/BlockHorizons/BlockPets/configurable/LanguageConfig.php
+++ b/src/BlockHorizons/BlockPets/configurable/LanguageConfig.php
@@ -31,6 +31,7 @@ class LanguageConfig {
             "commands.errors.console-use" => $language["commands"]["errors"]["console-use"],
             "commands.errors.no-permission" => $language["commands"]["errors"]["no-permission"],
             "commands.errors.pet.doesnt-exist" => $language["commands"]["errors"]["pet"]["doesnt-exist"],
+            "commands.errors.pet.numeric" => $language["commands"]["errors"]["pet"]["numeric"],
             "commands.errors.player.not-found" => $language["commands"]["errors"]["player"]["not-found"],
             "commands.errors.player.no-pet" => $language["commands"]["errors"]["player"]["no-pet"],
             "commands.errors.player.no-pet-other" => $language["commands"]["errors"]["player"]["no-pet-other"],
@@ -41,11 +42,17 @@ class LanguageConfig {
             "commands.healpet.success" => $language["commands"]["healpet"]["success"],
             
             "commands.spawnpet.no-permission" => $language["commands"]["spawnpet"]["no-permission"],
+            "commands.spawnpet.no-permission.other" => $language["commands"]["spawnpet"]["no-permission-others"],
+            "commands.spawnpet.success" => $language["commands"]["spawnpet"]["success"],
+            "commands.spawnpet.success.other" => $language["commands"]["spawnpet"]["success-other"],
+            "commands.spawnpet.name" => $language["commands"]["spawnpet"]["name"],
+            "commands.spawnpet.selecting-name" => $language["commands"]["spawnpet"]["selecting-name"],
+            "commands.spawnpet.exceeded-limit" => $language["commands"]["spawnpet"]["exceeded-limit"],
            
             "commands.removepet.success" => $language["commands"]["removepet"]["success"],
             
             "commands.togglepet.success" => $language["commands"]["togglepet"]["success"],
-            "commands.togglepet.success-other" => $language["commands"]["togglepet"]["success-other"]
+            "commands.togglepet.success.other" => $language["commands"]["togglepet"]["success-others"]
         ];
     }
 

--- a/src/BlockHorizons/BlockPets/configurable/LanguageConfig.php
+++ b/src/BlockHorizons/BlockPets/configurable/LanguageConfig.php
@@ -38,7 +38,14 @@ class LanguageConfig {
             "commands.changepetname.no-permission" => $language["commands"]["changepetname"]["no-permission"],
             "commands.changepetname.success" => $language["commands"]["changepetname"]["success"],
             
-            "commands.spawnpet.no-permission" => $language["commands"]["spawnpet"]["no-permission"]
+            "commands.healpet.success" => $language["commands"]["healpet"]["success"],
+            
+            "commands.spawnpet.no-permission" => $language["commands"]["spawnpet"]["no-permission"],
+           
+            "commands.removepet.success" => $language["commands"]["removepet"]["success"],
+            
+            "commands.togglepet.success" => $language["commands"]["togglepet"]["success"],
+            "commands.togglepet.success-other" => $language["commands"]["togglepet"]["success-other"]
         ];
     }
 

--- a/src/BlockHorizons/BlockPets/configurable/LanguageConfig.php
+++ b/src/BlockHorizons/BlockPets/configurable/LanguageConfig.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace BlockHorizons\BlockPets\configurable;
+
+use BlockHorizons\BlockPets\Loader;
+
+class LanguageConfig {
+
+    private $loader;
+    private $messages = [];
+
+    public function __construct(Loader $loader) {
+        $this->loader = $loader;
+        
+        $this->collectMessages();
+    }
+
+    public function collectMessages() {
+        $language = [];
+        foreach($this->getLoader()->availableLanguages as $availableLanguage) {
+            if($this->getLoader()->getBlockPetsConfig()->getLanguage() === $availableLanguage) {
+                $this->getLoader()->saveResource("languages/" . $availableLanguage . ".yml");
+                $language = yaml_parse_file($this->getLoader()->getDataFolder() . "languages/" . $availableLanguage . ".yml");
+            }
+        }
+        
+        // Don't look at this code, it harm you — or start a nuclear war. BlockHorizons and it's developers are not responsible for any physical damage as a result of staring at this code.
+        $this->messages = [
+            "prefix.warning" => $language["prefix"]["warning"],
+            
+            "commands.errors.console-use" => $language["commands"]["errors"]["console-use"],
+            "commands.errors.no-permission" => $language["commands"]["errors"]["no-permission"],
+            "commands.errors.pet.doesnt-exist" => $language["commands"]["errors"]["pet"]["doesnt-exist"],
+            "commands.errors.player.not-found" => $language["commands"]["errors"]["player"]["not-found"],
+            "commands.errors.player.no-pet" => $language["commands"]["errors"]["player"]["no-pet"],
+            "commands.errors.player.no-pet-other" => $language["commands"]["errors"]["player"]["no-pet-other"],
+            
+            "commands.changepetname.no-permission" => $language["commands"]["changepetname"]["no-permission"],
+            "commands.changepetname.success" => $language["commands"]["changepetname"]["success"],
+            
+            "commands.spawnpet.no-permission" => $language["commands"]["spawnpet"]["no-permission"]
+        ];
+    }
+
+    /**
+     * @return Loader
+     */
+    public function getLoader(): Loader {
+        return $this->loader;
+    }
+    
+    /**
+     * @param string $key
+     *
+     * @return mixed|null
+     */
+    public function get(string $key) {
+        return $this->messages[$key] ?? null;
+    }
+}

--- a/src/BlockHorizons/BlockPets/pets/BasePet.php
+++ b/src/BlockHorizons/BlockPets/pets/BasePet.php
@@ -458,9 +458,14 @@ abstract class BasePet extends Creature implements Rideable {
 		$this->positionSeekTick++;
 		if($this->shouldFindNewPosition()) {
 			if(!$this->getLoader()->getBlockPetsConfig()->shouldStalkPetOwner()) {
-				$this->xOffset = lcg_value() * (3 + $this->getScale());
-				$this->yOffset = lcg_value() * (3 + $this->getScale());
-				$this->zOffset = lcg_value() * (3 + $this->getScale());
+				if(rand(0, 1) === 1) {
+					$multiplicationValue = 1;
+				} else {
+					$multiplicationValue = -1;
+				}
+				$this->xOffset = lcg_value() * $multiplicationValue * (3 + $this->getScale());
+				$this->yOffset = lcg_value() * $multiplicationValue * (3 + $this->getScale());
+				$this->zOffset = lcg_value() * $multiplicationValue * (3 + $this->getScale());
 			}
 		}
 		$this->updateMovement();

--- a/src/BlockHorizons/BlockPets/pets/Calculator.php
+++ b/src/BlockHorizons/BlockPets/pets/Calculator.php
@@ -91,8 +91,4 @@ class Calculator {
 			}
 		}
 	}
-
-	public function saveInventory() {
-
-	}
 }

--- a/src/BlockHorizons/BlockPets/pets/IrasciblePet.php
+++ b/src/BlockHorizons/BlockPets/pets/IrasciblePet.php
@@ -72,8 +72,10 @@ abstract class IrasciblePet extends BasePet {
 	 * Sets the pet angry and it's target to the given entity, making it chase the entity.
 	 *
 	 * @param Living $entity
+	 *
+	 * @return bool
 	 */
-	public function setAngry(Living $entity) {
+	public function setAngry(Living $entity): bool {
 		if(!$this->canAttack) {
 			return false;
 		}

--- a/src/BlockHorizons/BlockPets/pets/datastorage/BaseDataStorer.php
+++ b/src/BlockHorizons/BlockPets/pets/datastorage/BaseDataStorer.php
@@ -11,7 +11,6 @@ abstract class BaseDataStorer {
 
 	public function __construct(Loader $loader) {
 		$this->loader = $loader;
-
 		$this->prepare();
 
 		if($this->getLoader()->getBlockPetsConfig()->doHardReset()) {

--- a/src/BlockHorizons/BlockPets/pets/datastorage/MySQLDataStorer.php
+++ b/src/BlockHorizons/BlockPets/pets/datastorage/MySQLDataStorer.php
@@ -71,7 +71,7 @@ class MySQLDataStorer extends BaseDataStorer {
 		if(!$this->petExists($petName, $ownerName)) {
 			return false;
 		}
-		$chested = $this->loader->getPetByName($petName, $ownerName)->isChested();
+		$chested = (int) $this->loader->getPetByName($petName, $ownerName)->isChested();
 		$query = "UPDATE Pets SET Chested = $chested WHERE Player = '" . $this->escape($ownerName) . "' AND PetName = '" . $this->escape($petName) . "'";
 		return $this->database->query($query);
 	}

--- a/src/BlockHorizons/BlockPets/pets/datastorage/SQLiteDataStorer.php
+++ b/src/BlockHorizons/BlockPets/pets/datastorage/SQLiteDataStorer.php
@@ -71,7 +71,7 @@ class SQLiteDataStorer extends BaseDataStorer {
 		if(!$this->petExists($petName, $ownerName)) {
 			return false;
 		}
-		$chested = $this->loader->getPetByName($petName, $ownerName)->isChested();
+		$chested = (int) $this->loader->getPetByName($petName, $ownerName)->isChested();
 		$query = "UPDATE Pets SET Chested = $chested WHERE Player = '" . $this->escape($ownerName) . "' AND PetName = '" . $this->escape($petName) . "'";
 		return $this->database->exec($query);
 	}


### PR DESCRIPTION
### Description
This pull requests adds customizable message support, including support for other languages if/when people contribute that. 

### API Changes
##### Added
* `BaseCommand->sendPermissionMessage(CommandSender $sender);`
* `BaseCommand->sendWarning(CommandSender $sender, string $text);`
* `Loader->translate(string $text, array $params = []);`

... and more

### Config
New config value:
```yaml
# The language to be used in messages in this plugin.
# Available options:
#  en
Language: en
```
### TODO
* Replace `§` with `&` in the language file... would require me to add *another* helper method to send a message to the sender while running `str_replace`.

Hope this doesn't break anything 😂