### PR TITLE
API update 3.0.0-ALPHA11

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,9 +3,7 @@ name: "BlockPets"
 author: "BlockHorizons"
 version: 1.1.0
 api:
-- 3.0.0-ALPHA7
-- 3.0.0-ALPHA8
-- 3.0.0-ALPHA9
+- 3.0.0-ALPHA11
 main: BlockHorizons\BlockPets\Loader
 
 permissions:

--- a/src/BlockHorizons/BlockPets/pets/BasePet.php
+++ b/src/BlockHorizons/BlockPets/pets/BasePet.php
@@ -551,7 +551,7 @@ abstract class BasePet extends Creature implements Rideable {
 		$link->fromEntityUniqueId = $this->getId();
 		$link->type = self::STATE_STANDING;
 		$link->toEntityUniqueId = $this->getPetOwner()->getId();
-		$link->byte2 = 1;
+		$link->bool1 = true;
 
 		$pk->link = $link;
 		$this->ridden = false;
@@ -566,7 +566,7 @@ abstract class BasePet extends Creature implements Rideable {
 		$link->fromEntityUniqueId = $this->getPetOwner()->getId();
 		$link->type = self::STATE_STANDING;
 		$link->toEntityUniqueId = 0;
-		$link->byte2 = 1;
+		$link->bool1 = true;
 
 		$pk->link = $link;
 		$this->getPetOwner()->dataPacket($pk);
@@ -603,11 +603,11 @@ abstract class BasePet extends Creature implements Rideable {
 		$this->ridden = true;
 		$this->rider = $player->getName();
 		$player->canCollide = false;
-		$this->getPetOwner()->propertyManager->setPropertyValue(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, [0, 1.8 + $this->getScale() * 0.9, -0.25]);
+		$this->getPetOwner()->propertyManager->setPropertyValue(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, new Vector3(0, 1.8 + $this->getScale() * 0.9, -0.25));
 		if($this instanceof EnderDragonPet) {
-			$player->propertyManager->setPropertyValue(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, [0, 2.65 + $this->getScale(), -1.7]);
+			$player->propertyManager->setPropertyValue(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, new Vector3(0, 2.65 + $this->getScale(), -1.7));
 		} elseif($this instanceof SmallCreature) {
-			$player->propertyManager->setPropertyValue(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, [0, 0.78 + $this->getScale() * 0.9, -0.25]);
+			$player->propertyManager->setPropertyValue(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, new Vector3(0, 0.78 + $this->getScale() * 0.9, -0.25));
 		}
 		$player->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_RIDING, true);
 		$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_SADDLED, true);
@@ -617,7 +617,7 @@ abstract class BasePet extends Creature implements Rideable {
 		$link->fromEntityUniqueId = $this->getId();
 		$link->type = self::STATE_SITTING;
 		$link->toEntityUniqueId = $player->getId();
-		$link->byte2 = 1;
+		$link->bool1 = true;
 
 		$pk->link = $link;
 		$this->server->broadcastPacket($this->server->getOnlinePlayers(), $pk);
@@ -627,7 +627,7 @@ abstract class BasePet extends Creature implements Rideable {
 		$link->fromEntityUniqueId = $this->getId();
 		$link->type = self::STATE_SITTING;
 		$link->toEntityUniqueId = 0;
-		$link->byte2 = 1;
+		$link->bool1 = true;
 
 		$pk->link = $link;
 		$player->dataPacket($pk);
@@ -672,7 +672,7 @@ abstract class BasePet extends Creature implements Rideable {
 		$pk->motion = new Vector3(0.0, 0.0, 0.0);
 		$pk->yaw = $this->yaw;
 		$pk->pitch = $this->pitch;
-		$pk->metadata = $this->dataProperties;
+		$pk->metadata = $this->propertyManager->getAll();
 		$player->dataPacket($pk);
 
 		$pk = new UpdateAttributesPacket();
@@ -779,7 +779,7 @@ abstract class BasePet extends Creature implements Rideable {
 			return false;
 		}
 		$this->riding = true;
-		$this->propertyManager->setPropertyValue(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, [0, $this->getScale() * 0.4 - 0.3, 0]);
+		$this->propertyManager->setPropertyValue(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, new Vector3(0, $this->getScale() * 0.4 - 0.3, 0));
 		$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_RIDING, true);
 
 		$pk = new SetEntityLinkPacket();
@@ -787,7 +787,7 @@ abstract class BasePet extends Creature implements Rideable {
 		$link->fromEntityUniqueId = $this->getPetOwner()->getId();
 		$link->type = self::STATE_SITTING;
 		$link->toEntityUniqueId = $this->getId();
-		$link->byte2 = 1;
+		$link->bool1 = true;
 
 		$pk->link = $link;
 		$this->server->broadcastPacket($this->server->getOnlinePlayers(), $pk);
@@ -810,7 +810,7 @@ abstract class BasePet extends Creature implements Rideable {
 		$link->fromEntityUniqueId = $this->getPetOwner()->getId();
 		$link->type = self::STATE_STANDING;
 		$link->toEntityUniqueId = $this->getId();
-		$link->byte2 = 1;
+		$link->bool1 = true;
 
 		$pk->link = $link;
 		$this->server->broadcastPacket($this->server->getOnlinePlayers(), $pk);

--- a/src/BlockHorizons/BlockPets/pets/BasePet.php
+++ b/src/BlockHorizons/BlockPets/pets/BasePet.php
@@ -402,7 +402,7 @@ abstract class BasePet extends Creature implements Rideable {
 	public function initEntity() {
 		parent::initEntity();
 		$this->generateCustomPetData();
-		$this->setDataProperty(self::DATA_FLAG_NO_AI, self::DATA_TYPE_BYTE, 1);
+		$this->propertyManager->setPropertyValue(self::DATA_FLAG_NO_AI, self::DATA_TYPE_BYTE, 1);
 	}
 
 	public function generateCustomPetData(): void {
@@ -603,11 +603,11 @@ abstract class BasePet extends Creature implements Rideable {
 		$this->ridden = true;
 		$this->rider = $player->getName();
 		$player->canCollide = false;
-		$this->getPetOwner()->setDataProperty(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, [0, 1.8 + $this->getScale() * 0.9, -0.25]);
+		$this->getPetOwner()->propertyManager->setPropertyValue(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, [0, 1.8 + $this->getScale() * 0.9, -0.25]);
 		if($this instanceof EnderDragonPet) {
-			$player->setDataProperty(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, [0, 2.65 + $this->getScale(), -1.7]);
+			$player->propertyManager->setPropertyValue(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, [0, 2.65 + $this->getScale(), -1.7]);
 		} elseif($this instanceof SmallCreature) {
-			$player->setDataProperty(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, [0, 0.78 + $this->getScale() * 0.9, -0.25]);
+			$player->propertyManager->setPropertyValue(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, [0, 0.78 + $this->getScale() * 0.9, -0.25]);
 		}
 		$player->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_RIDING, true);
 		$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_SADDLED, true);
@@ -779,7 +779,7 @@ abstract class BasePet extends Creature implements Rideable {
 			return false;
 		}
 		$this->riding = true;
-		$this->setDataProperty(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, [0, $this->getScale() * 0.4 - 0.3, 0]);
+		$this->propertyManager->setPropertyValue(self::DATA_RIDER_SEAT_POSITION, self::DATA_TYPE_VECTOR3F, [0, $this->getScale() * 0.4 - 0.3, 0]);
 		$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_RIDING, true);
 
 		$pk = new SetEntityLinkPacket();
@@ -792,6 +792,7 @@ abstract class BasePet extends Creature implements Rideable {
 		$pk->link = $link;
 		$this->server->broadcastPacket($this->server->getOnlinePlayers(), $pk);
 		return true;
+
 	}
 
 	/**

--- a/src/BlockHorizons/BlockPets/pets/creatures/CaveSpiderPet.php
+++ b/src/BlockHorizons/BlockPets/pets/creatures/CaveSpiderPet.php
@@ -18,6 +18,6 @@ class CaveSpiderPet extends WalkingPet implements SmallCreature {
 	public $networkId = 40;
 
 	public function generateCustomPetData(): void {
-		$this->setDataProperty(self::DATA_FLAGS, self::DATA_FLAG_CAN_CLIMB, true);
+		$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_CAN_CLIMB, true);
 	}
 }

--- a/src/BlockHorizons/BlockPets/pets/creatures/HorsePet.php
+++ b/src/BlockHorizons/BlockPets/pets/creatures/HorsePet.php
@@ -24,6 +24,6 @@ class HorsePet extends WalkingPet {
 			1024, 1025, 1026, 1027, 1028, 1029, 1030
 		];
 		$randomVariant = $variants[array_rand($variants)];
-		$this->setDataProperty(self::DATA_VARIANT, self::DATA_TYPE_INT, $randomVariant);
+		$this->propertyManager->setPropertyValue(self::DATA_VARIANT, self::DATA_TYPE_INT, $randomVariant);
 	}
 }

--- a/src/BlockHorizons/BlockPets/pets/creatures/LlamaPet.php
+++ b/src/BlockHorizons/BlockPets/pets/creatures/LlamaPet.php
@@ -16,6 +16,6 @@ class LlamaPet extends WalkingPet {
 
 	public function generateCustomPetData(): void {
 		$randomVariant = random_int(0, 3);
-		$this->setDataProperty(self::DATA_VARIANT, self::DATA_TYPE_INT, $randomVariant);
+		$this->propertyManager->setPropertyValue(self::DATA_VARIANT, self::DATA_TYPE_INT, $randomVariant);
 	}
 }

--- a/src/BlockHorizons/BlockPets/pets/creatures/OcelotPet.php
+++ b/src/BlockHorizons/BlockPets/pets/creatures/OcelotPet.php
@@ -17,6 +17,6 @@ class OcelotPet extends WalkingPet implements SmallCreature {
 
 	public function generateCustomPetData(): void {
 		$randomVariant = random_int(0, 3);
-		$this->setDataProperty(self::DATA_VARIANT, self::DATA_TYPE_INT, $randomVariant);
+		$this->propertyManager->setPropertyValue(self::DATA_VARIANT, self::DATA_TYPE_INT, $randomVariant);
 	}
 }

--- a/src/BlockHorizons/BlockPets/pets/creatures/RabbitPet.php
+++ b/src/BlockHorizons/BlockPets/pets/creatures/RabbitPet.php
@@ -21,6 +21,6 @@ class RabbitPet extends BouncingPet implements SmallCreature {
 			0, 1, 2, 3, 4, 5, 99
 		];
 		$randomVariant = $variants[array_rand($variants)];
-		$this->setDataProperty(self::DATA_VARIANT, self::DATA_TYPE_INT, $randomVariant);
+		$this->propertyManager->setPropertyValue(self::DATA_VARIANT, self::DATA_TYPE_INT, $randomVariant);
 	}
 }

--- a/src/BlockHorizons/BlockPets/pets/creatures/SheepPet.php
+++ b/src/BlockHorizons/BlockPets/pets/creatures/SheepPet.php
@@ -16,7 +16,7 @@ class SheepPet extends WalkingPet {
 
 	public function generateCustomPetData(): void {
 		$randomColour = random_int(0, 15);
-		$this->setDataProperty(self::DATA_COLOUR, self::DATA_TYPE_BYTE, $randomColour);
+		$this->propertyManager->setPropertyValue(self::DATA_COLOUR, self::DATA_TYPE_BYTE, $randomColour);
 	}
 
 	/**

--- a/src/BlockHorizons/BlockPets/pets/creatures/SpiderPet.php
+++ b/src/BlockHorizons/BlockPets/pets/creatures/SpiderPet.php
@@ -16,6 +16,6 @@ class SpiderPet extends WalkingPet implements SmallCreature {
 	public $networkId = 35;
 
 	public function generateCustomPetData(): void {
-		$this->setDataProperty(self::DATA_FLAGS, self::DATA_FLAG_CAN_CLIMB, true);
+		$this->propertyManager->setPropertyValue(self::DATA_FLAGS, self::DATA_FLAG_CAN_CLIMB, true);
 	}
 }

--- a/src/BlockHorizons/BlockPets/pets/creatures/VillagerPet.php
+++ b/src/BlockHorizons/BlockPets/pets/creatures/VillagerPet.php
@@ -16,6 +16,6 @@ class VillagerPet extends WalkingPet {
 
 	public function generateCustomPetData(): void {
 		$randomVariant = random_int(0, 5);
-		$this->setDataProperty(self::DATA_VARIANT, self::DATA_TYPE_INT, $randomVariant);
+		$this->propertyManager->setPropertyValue(self::DATA_VARIANT, self::DATA_TYPE_INT, $randomVariant);
 	}
 }

--- a/src/BlockHorizons/BlockPets/pets/creatures/WolfPet.php
+++ b/src/BlockHorizons/BlockPets/pets/creatures/WolfPet.php
@@ -17,6 +17,6 @@ class WolfPet extends WalkingPet implements SmallCreature {
 
 	public function generateCustomPetData(): void {
 		$randomColour = random_int(0, 15);
-		$this->setDataProperty(self::DATA_COLOUR, self::DATA_TYPE_BYTE, $randomColour);
+		$this->propertyManager->setPropertyValue(self::DATA_COLOUR, self::DATA_TYPE_BYTE, $randomColour);
 	}
 }

--- a/src/BlockHorizons/BlockPets/pets/inventory/PetInventoryHolder.php
+++ b/src/BlockHorizons/BlockPets/pets/inventory/PetInventoryHolder.php
@@ -7,6 +7,7 @@ namespace BlockHorizons\BlockPets\pets\inventory;
 use BlockHorizons\BlockPets\pets\BasePet;
 use pocketmine\block\Block;
 use pocketmine\item\Item;
+use pocketmine\nbt\BigEndianNBTStream;
 use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntTag;
@@ -107,7 +108,7 @@ class PetInventoryHolder {
 		foreach($items as &$item) {
 			$item = $item->nbtSerialize(-1, "Item");
 		}
-		$nbt = new NBT(NBT::BIG_ENDIAN);
+		$nbt = new BigEndianNBTStream();
 		$compressedContents = new CompoundTag("Items", [
 			new ListTag("ItemList", $items)
 		]);


### PR DESCRIPTION
There were a couple of necessary changes dealing with NBT storage, data properties handling, and EntityLink methods.  These changes cause breaks in backwards compatibility.

In summary:
All uses of `setDataProperty` have been updated to use `propertyManager->setPropertyValue()`
Creation of NBT in `PetInventoryHolder` has been updated to use BigEndianNBTStream
Values of properties with type `DATA_TYPE_VECTOR3F` were set to use `Vector3` instead of arrays
Values of properties with type `DATA_TYPE_BOOL` were set to use boolean values of true of false to avoid potential integer conflicts.