### PR TITLE
Implement Saddles.

### DIFF
--- a/src/BlockHorizons/BlockPets/Loader.php
+++ b/src/BlockHorizons/BlockPets/Loader.php
@@ -19,6 +19,7 @@ use BlockHorizons\BlockPets\configurable\LanguageConfig;
 use BlockHorizons\BlockPets\configurable\PetProperties;
 use BlockHorizons\BlockPets\events\PetRemoveEvent;
 use BlockHorizons\BlockPets\events\PetSpawnEvent;
+use BlockHorizons\BlockPets\items\Saddle;
 use BlockHorizons\BlockPets\listeners\EventListener;
 use BlockHorizons\BlockPets\listeners\RidingListener;
 use BlockHorizons\BlockPets\pets\BasePet;
@@ -75,6 +76,8 @@ use BlockHorizons\BlockPets\pets\datastorage\MySQLDataStorer;
 use BlockHorizons\BlockPets\pets\datastorage\SQLiteDataStorer;
 use pocketmine\entity\Attribute;
 use pocketmine\entity\Entity;
+use pocketmine\item\Item;
+use pocketmine\item\ItemFactory;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\DoubleTag;
@@ -228,6 +231,9 @@ class Loader extends PluginBase {
 		foreach(self::PET_CLASSES as $petClass) {
 			Entity::registerEntity($petClass, true);
 		}
+		ItemFactory::registerItem(new Saddle, true);
+		$saddle = Item::get(Saddle::SADDLE);
+		Item::addCreativeItem($saddle);
 		$this->registerCommands();
 		$this->registerListeners();
 

--- a/src/BlockHorizons/BlockPets/items/Saddle.php
+++ b/src/BlockHorizons/BlockPets/items/Saddle.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace BlockHorizons\BlockPets\items;
+
+
+use pocketmine\item\Item;
+
+class Saddle extends Item{
+	public function __construct(int $meta = 0){
+		parent::__construct(self::SADDLE, $meta, "Saddle");
+	}
+
+}


### PR DESCRIPTION
The 3.0.0-ALPHA11 update to PocketMine-MP caused some change to how saddles work.  This will correctly implement saddles and add them to Creative Inventory.