### PR TITLE
Temporary fix for the spawn of non-pet entities

### DIFF
--- a/src/BlockHorizons/BlockPets/pets/BasePet.php
+++ b/src/BlockHorizons/BlockPets/pets/BasePet.php
@@ -107,8 +107,8 @@ abstract class BasePet extends Creature implements Rideable {
 	private $maxSize = 10.0;
 
 	public function __construct(Level $level, CompoundTag $nbt) {
-		$this->petOwner = $level->getServer()->getPlayerExact($nbt->getString("petOwner"));
-		if($this->petOwner === null) {
+		$this->petOwner = $level->getServer()->getPlayerExact($nbt->getString("petOwner", false));
+		if($this->petOwner === false) {
 			$this->close();
 			return;
 		}


### PR DESCRIPTION
The problem with the default return value being null was that when the default returnable is null and the Tag that you're trying to get does not exist in the NBT, a RuntimeException is thrown, accordingly a crash happens.